### PR TITLE
Add market cap command (as a millionaire)

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,6 @@
 // todo: should this go into types
 import { handleHolders } from './holders';
+import { handleMarketCap } from './mcap';
 
 export {
     createOriginal,
@@ -18,4 +19,5 @@ export const handlers: {
 } = {
     '860831571078283266': handlePrice,
     '862306068369244250': handleHolders,
+    '': handleMarketCap
 };

--- a/src/commands/mcap.ts
+++ b/src/commands/mcap.ts
@@ -1,0 +1,42 @@
+import { InteractionResponseType } from 'slash-commands/dist/src/structures';
+
+export async function handleMarketCap(
+    req: InteractionRequest,
+): Promise<InteractionResponse> {
+    const apiUrl = "https://api.coingecko.com/api/v3/coins/million?tickers=false&market_data=true&community_data=false&developer_data=false&sparkline=false";
+    const init = {
+        headers: {
+            "content-type": "application/json;charset=UTF-8",
+        },
+    }
+
+    let commandResponse;
+
+    try {
+        const response = await fetch(apiUrl, init);
+        const responseBody = await response.json()
+        const marketCapUsd = responseBody.market_data.market_cap.usd;
+
+        commandResponse = `Current market cap is **$${formatLargeNumber(marketCapUsd)}**.`;
+    } catch {
+        commandResponse = `Something is wrong - try again a bit later.`;
+    }
+
+    return {
+        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        data: {
+            content: commandResponse
+        }
+    };
+}
+
+function formatLargeNumber(number) {
+    const num = Math.abs(Number(number));
+    return num >= 1.0e+9
+        ? (num / 1.0e+9).toFixed(2) + "B"
+        : num >= 1.0e+6
+            ? (num / 1.0e+6).toFixed(2) + "M"
+            : num >= 1.0e+3
+                ? (num / 1.0e+3).toFixed(2) + "K"
+                : num;
+}


### PR DESCRIPTION
Adding a new command for market cap. I think the command should be `/mcap`, so people don't need to type the full "marketcap" all the time.

You could say the command is unnecessary, because you can instantly calculate it from the price. I sort of agree, but oh well :slightly_smiling_face:  I wanted to create a command :slightly_smiling_face:

The coingecko API claims to have a rate limit of 50 / minute, which _might_ be exceeded given the discord channel's traffic, so I put in some simple error handling. However, I did test with 50+ requests and it worked, only got errors when I submitted ~70 requests in 10 seconds.

The PR needs some additional work - see comments below.