### PR TITLE
Add emojis to commands (as a millionaire)

### DIFF
--- a/src/commands/holders.ts
+++ b/src/commands/holders.ts
@@ -15,7 +15,7 @@ export async function handleHolders(
     return {
         type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
         data: {
-            content: `Current holders count is **${responseBody.tokenInfo.holdersCount}**.`,
+            content: `:diamondhands: Current holders count is **${responseBody.tokenInfo.holdersCount}**.`,
         },
     };
 }

--- a/src/commands/mcap.ts
+++ b/src/commands/mcap.ts
@@ -18,7 +18,7 @@ export async function handleMarketCap(
         const responseBody = await response.json()
         const marketCapUsd = responseBody.market_data.market_cap.usd;
 
-        commandResponse = `Current market cap is **$${formatLargeNumber(marketCapUsd)}**.`;
+        commandResponse = `:rocket: Current market cap is **$${formatLargeNumber(marketCapUsd)}**.`;
     } catch {
         commandResponse = `Something is wrong - try again a bit later.`;
     }

--- a/src/commands/volume.ts
+++ b/src/commands/volume.ts
@@ -20,7 +20,7 @@ export async function handleVolume(
         const volumeChange = dailyData.volume_change_pct;
         commandResponse = `24h volume is **$${formatLargeNumber(volume)}** (${formatPercentageChange(volumeChange)}%).`;
     } catch {
-        commandResponse = `Something is wrong - try again a bit later.`;
+        commandResponse = `:bar_chart: Something is wrong - try again a bit later.`;
     }
     return {
         type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,

--- a/src/commands/volume.ts
+++ b/src/commands/volume.ts
@@ -18,9 +18,9 @@ export async function handleVolume(
         const dailyData = responseBody[0]['1d'];
         const volume = dailyData.volume;
         const volumeChange = dailyData.volume_change_pct;
-        commandResponse = `24h volume is **$${formatLargeNumber(volume)}** (${formatPercentageChange(volumeChange)}%).`;
+        commandResponse = `:bar_chart: 24h volume is **$${formatLargeNumber(volume)}** (${formatPercentageChange(volumeChange)}%).`;
     } catch {
-        commandResponse = `:bar_chart: Something is wrong - try again a bit later.`;
+        commandResponse = `Something is wrong - try again a bit later.`;
     }
     return {
         type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,


### PR DESCRIPTION
It will help differentiate command messages on chat.

The market cap message is too similar to the price message, but the market cap takes more time to update, which cause confusion when reading the chat fast.

Add diamond hands to holder count:
![image](https://user-images.githubusercontent.com/6069943/125684740-edc37c54-4042-4c86-bfcb-364e88d617f8.png)

Rocket emoji to marketcap:
![image](https://user-images.githubusercontent.com/6069943/125684868-f264109f-4962-444f-9cb0-6e8d62ee9810.png)

Bar chart to volume:
![image](https://user-images.githubusercontent.com/6069943/125684948-ce94cddf-10e7-4813-8a74-c51aeb845cca.png)


